### PR TITLE
Make WizardObserver non-abstract for convenience

### DIFF
--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 
 /// An interface for observing the behavior of a [Wizard].
-abstract class WizardObserver {
+class WizardObserver {
   /// The wizard returned from [nextRoute] to [previousRoute].
-  void onBack(Route previousRoute, Route? nextRoute);
+  void onBack(Route previousRoute, Route? nextRoute) {}
 
   /// The wizard moved from [previousRoute] to [nextRoute].
-  void onNext(Route nextRoute, Route? previousRoute);
+  void onNext(Route nextRoute, Route? previousRoute) {}
 
   /// The wizard was done at [route].
-  FutureOr<void> onDone(Route route, Object? result);
+  FutureOr<void> onDone(Route route, Object? result) {}
 }


### PR DESCRIPTION
Provide empty stubs - don't force to implement the whole observer API.