### PR TITLE
Remove non-existent routes when rebuilt

### DIFF
--- a/lib/src/wizard.dart
+++ b/lib/src/wizard.dart
@@ -182,15 +182,28 @@ class Wizard extends StatefulWidget {
 }
 
 class _WizardState extends State<Wizard> {
-  late List<WizardRouteSettings> _routes;
+  List<WizardRouteSettings> _routes = [];
 
   @override
   void initState() {
     super.initState();
-    _routes = <WizardRouteSettings>[
-      WizardRouteSettings(
-          name: widget.initialRoute ?? widget.routes.keys.first),
-    ];
+    _ensureInitialRoute();
+  }
+
+  @override
+  void didUpdateWidget(Wizard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _routes.removeWhere((r) => !widget.routes.containsKey(r.name));
+    _ensureInitialRoute();
+  }
+
+  void _ensureInitialRoute() {
+    if (_routes.isEmpty) {
+      _routes = <WizardRouteSettings>[
+        WizardRouteSettings(
+            name: widget.initialRoute ?? widget.routes.keys.first),
+      ];
+    }
   }
 
   Page _createPage(BuildContext context,

--- a/test/wizard_router_test.dart
+++ b/test/wizard_router_test.dart
@@ -714,4 +714,33 @@ void main() {
     expect(find.text(Routes.second), findsNothing);
     expect(find.text(Routes.third), findsOneWidget);
   });
+
+  testWidgets('rebuild with different routes', (tester) async {
+    await pumpWizardApp(
+      tester,
+      routes: {
+        Routes.first: WizardRoute(builder: (_) => const Text(Routes.first)),
+        Routes.second: WizardRoute(builder: (_) => const Text(Routes.second)),
+        Routes.third: WizardRoute(builder: (_) => const Text(Routes.third)),
+      },
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(Routes.first), findsOneWidget);
+    expect(find.text(Routes.second), findsNothing);
+    expect(find.text(Routes.third), findsNothing);
+
+    await pumpWizardApp(
+      tester,
+      routes: {
+        Routes.second: WizardRoute(builder: (_) => const Text(Routes.second)),
+        Routes.third: WizardRoute(builder: (_) => const Text(Routes.third)),
+      },
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(Routes.first), findsNothing);
+    expect(find.text(Routes.second), findsOneWidget);
+    expect(find.text(Routes.third), findsNothing);
+  });
 }


### PR DESCRIPTION
If a wizard has routes conditionally left out when rebuilt, make sure to remove them from the stack to avoid referencing non-existent routes when building pages.

For example, the installer could have an automated installation flow as such:
```dart
[
  '/loading',
  if (needsConfirmation) '/confirm',
  '/slides',
  '/complete'
]
```
where the confirmation step is conditional depending on async responses from Subiquity.

Ref: canonical/ubuntu-desktop-installer#1412