### PR TITLE
Add user data properties to `WizardRoute` and `Wizard`

### DIFF
--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -15,7 +15,7 @@ class WizardRoute {
     this.onReplace,
     this.onBack,
     this.onDone,
-    this.userData = const {},
+    this.userData,
   });
 
   final WidgetBuilder builder;
@@ -42,5 +42,5 @@ class WizardRoute {
   final WizardDoneCallback? onDone;
 
   /// Additional custom data associated with this page.
-  final Map<String, dynamic> userData;
+  final Object? userData;
 }

--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -15,6 +15,7 @@ class WizardRoute {
     this.onReplace,
     this.onBack,
     this.onDone,
+    this.userData = const {},
   });
 
   final WidgetBuilder builder;
@@ -39,4 +40,7 @@ class WizardRoute {
 
   /// The callback invoked when the wizard is done.
   final WizardDoneCallback? onDone;
+
+  /// Additional custom data associated with this page.
+  final Map<String, dynamic> userData;
 }

--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flow_builder/flow_builder.dart';
 import 'package:flutter/widgets.dart';
@@ -16,13 +17,16 @@ class WizardScope extends StatefulWidget {
     required int index,
     required WizardRoute route,
     required List<String> routes,
+    required Map<String, dynamic> userData,
   })  : _index = index,
         _route = route,
-        _routes = routes;
+        _routes = routes,
+        _userData = userData;
 
   final int _index;
   final WizardRoute _route;
   final List<String> _routes;
+  final Map<String, dynamic> _userData;
 
   @override
   State<WizardScope> createState() => WizardScopeState();
@@ -192,6 +196,11 @@ class WizardScopeState extends State<WizardScope> {
 
   /// Returns `true` if the wizard is done.
   bool get isDone => context.flow<List<WizardRouteSettings>>().completed;
+
+  UnmodifiableMapView<String, dynamic> get routeData =>
+      UnmodifiableMapView(widget._route.userData);
+  UnmodifiableMapView<String, dynamic> get wizardData =>
+      UnmodifiableMapView(widget._userData);
 
   @override
   Widget build(BuildContext context) => Builder(builder: widget._route.builder);

--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:flow_builder/flow_builder.dart';
 import 'package:flutter/widgets.dart';
@@ -17,7 +16,7 @@ class WizardScope extends StatefulWidget {
     required int index,
     required WizardRoute route,
     required List<String> routes,
-    required Map<String, dynamic> userData,
+    Object? userData,
   })  : _index = index,
         _route = route,
         _routes = routes,
@@ -26,7 +25,7 @@ class WizardScope extends StatefulWidget {
   final int _index;
   final WizardRoute _route;
   final List<String> _routes;
-  final Map<String, dynamic> _userData;
+  final Object? _userData;
 
   @override
   State<WizardScope> createState() => WizardScopeState();
@@ -197,10 +196,8 @@ class WizardScopeState extends State<WizardScope> {
   /// Returns `true` if the wizard is done.
   bool get isDone => context.flow<List<WizardRouteSettings>>().completed;
 
-  UnmodifiableMapView<String, dynamic> get routeData =>
-      UnmodifiableMapView(widget._route.userData);
-  UnmodifiableMapView<String, dynamic> get wizardData =>
-      UnmodifiableMapView(widget._userData);
+  Object? get routeData => widget._route.userData;
+  Object? get wizardData => widget._userData;
 
   @override
   Widget build(BuildContext context) => Builder(builder: widget._route.builder);

--- a/lib/src/wizard.dart
+++ b/lib/src/wizard.dart
@@ -114,6 +114,7 @@ class Wizard extends StatefulWidget {
     this.initialRoute,
     required this.routes,
     this.observers = const [],
+    this.userData = const {},
   });
 
   /// The name of the first route to show.
@@ -127,6 +128,9 @@ class Wizard extends StatefulWidget {
   /// The order of `routes` is the order of the wizard pages are shown. The
   /// order can be customized with [WizardRoute.onNext] and [WizardRoute.onBack].
   final Map<String, WizardRoute> routes;
+
+  /// Additional custom data associated with this page.
+  final Map<String, dynamic> userData;
 
   /// The wizard scope from the closest instance of this class that encloses the
   /// given `context`.
@@ -216,6 +220,7 @@ class _WizardState extends State<Wizard> {
         index: index,
         route: widget.routes[settings.name]!,
         routes: widget.routes.keys.toList(),
+        userData: widget.userData,
       ),
     );
   }

--- a/lib/src/wizard.dart
+++ b/lib/src/wizard.dart
@@ -114,7 +114,7 @@ class Wizard extends StatefulWidget {
     this.initialRoute,
     required this.routes,
     this.observers = const [],
-    this.userData = const {},
+    this.userData,
   });
 
   /// The name of the first route to show.
@@ -130,7 +130,7 @@ class Wizard extends StatefulWidget {
   final Map<String, WizardRoute> routes;
 
   /// Additional custom data associated with this page.
-  final Map<String, dynamic> userData;
+  final Object? userData;
 
   /// The wizard scope from the closest instance of this class that encloses the
   /// given `context`.

--- a/test/wizard_router_test.dart
+++ b/test/wizard_router_test.dart
@@ -58,7 +58,7 @@ void main() {
     WidgetTester tester, {
     String? initialRoute,
     required Map<String, WizardRoute> routes,
-    Map<String, dynamic> userData = const {},
+    Object? userData,
   }) {
     return tester.pumpWidget(
       MaterialApp(
@@ -753,8 +753,9 @@ void main() {
         Routes.first: WizardRoute(
           builder: (context) {
             final wizardScope = Wizard.of(context);
-            final page = wizardScope.routeData['page'] ?? -1;
-            final totalPages = wizardScope.wizardData['totalPages'] ?? -1;
+            final page = (wizardScope.routeData as Map)['page'] ?? -1;
+            final totalPages =
+                (wizardScope.wizardData as Map)['totalPages'] ?? -1;
             return Column(
               children: [
                 Text(Routes.first),

--- a/test/wizard_router_test.dart
+++ b/test/wizard_router_test.dart
@@ -58,12 +58,14 @@ void main() {
     WidgetTester tester, {
     String? initialRoute,
     required Map<String, WizardRoute> routes,
+    Map<String, dynamic> userData = const {},
   }) {
     return tester.pumpWidget(
       MaterialApp(
         home: Wizard(
           initialRoute: initialRoute,
           routes: routes,
+          userData: userData,
         ),
       ),
     );
@@ -742,5 +744,37 @@ void main() {
     expect(find.text(Routes.first), findsNothing);
     expect(find.text(Routes.second), findsOneWidget);
     expect(find.text(Routes.third), findsNothing);
+  });
+
+  testWidgets('user data', (tester) async {
+    await pumpWizardApp(
+      tester,
+      routes: {
+        Routes.first: WizardRoute(
+          builder: (context) {
+            final wizardScope = Wizard.of(context);
+            final page = wizardScope.routeData['page'] ?? -1;
+            final totalPages = wizardScope.wizardData['totalPages'] ?? -1;
+            return Column(
+              children: [
+                Text(Routes.first),
+                Text('Page $page of $totalPages'),
+              ],
+            );
+          },
+          userData: {'page': 1},
+        ),
+        Routes.second: WizardRoute(
+          builder: (_) => const Text(Routes.second),
+        ),
+      },
+      userData: {'totalPages': 3},
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(Routes.first), findsOneWidget);
+    expect(find.text(Routes.second), findsNothing);
+
+    expect(find.text('Page 1 of 3'), findsOneWidget);
   });
 }


### PR DESCRIPTION
This adds maps that can store supplemental information for `Wizard`s and `WizardRoute`s, e.g. to keep track of the progress through the wizard.