### PR TITLE
Implement optional controller for alternate control of Wizard

### DIFF
--- a/example/lib/actions.dart
+++ b/example/lib/actions.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:wizard_router/wizard_router.dart';
+
+class WizardNextIntent extends Intent {
+  final Object? arguments;
+
+  WizardNextIntent({this.arguments});
+
+  static void invoke({required BuildContext context, Object? arguments}) {
+    Actions.invoke(
+      context,
+      WizardNextIntent(arguments: arguments),
+    );
+  }
+}
+
+class WizardBackIntent extends Intent {
+  final Object? arguments;
+  WizardBackIntent({
+    this.arguments,
+  });
+
+  static void invoke({required BuildContext context, Object? arguments}) {
+    Actions.invoke(
+      context,
+      WizardBackIntent(arguments: arguments),
+    );
+  }
+}
+
+wizardActions({required WizardController controller}) => {
+      WizardNextIntent: CallbackAction<WizardNextIntent>(
+        onInvoke: (intent) => controller.next(arguments: intent.arguments),
+      ),
+      WizardBackIntent: CallbackAction<WizardBackIntent>(
+        onInvoke: (intent) => controller.back(arguments: intent.arguments),
+      )
+    };

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,9 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'package:wizard_router/wizard_router.dart';
+import 'package:wizard_router_example/actions.dart';
 
 import 'models.dart';
 import 'pages.dart';
@@ -12,51 +15,61 @@ void main() {
   runApp(
     ChangeNotifierProvider(
       create: (_) => NetworkModel(service),
-      child: const WizardApp(),
+      child: WizardApp(),
     ),
   );
 }
 
 class WizardApp extends StatelessWidget {
-  const WizardApp({Key? key}) : super(key: key);
+  WizardApp({Key? key}) : super(key: key);
+
+  /// Optional to show use of Actions + controller in example
+  /// Off by default to not affect tests.
+  static bool useActions = false;
+
+  final WizardController controller = WizardController();
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Wizard(
-        initialRoute: Routes.initial,
-        routes: <String, WizardRoute>{
-          Routes.welcome: WizardRoute(
-            builder: WelcomePage.create,
-          ),
-          Routes.chooser: WizardRoute(
-            builder: ChooserPage.create,
-            onNext: (settings) {
-              switch (settings.arguments as Choice?) {
-                case Choice.preview:
-                  return Routes.preview;
-                case Choice.install:
-                  if (!context.read<NetworkModel>().isConnected) {
-                    return Routes.connect;
-                  }
-                  return Routes.install;
-                default:
-                  throw ArgumentError(settings.arguments);
-              }
-            },
-          ),
-          Routes.preview: WizardRoute(
-            builder: PreviewPage.create,
-          ),
-          Routes.connect: WizardRoute(
-            builder: ConnectPage.create,
-            onBack: (_) => Routes.chooser,
-          ),
-          Routes.install: WizardRoute(
-            builder: InstallPage.create,
-            onBack: (_) => Routes.chooser,
-          ),
-        },
+      home: Actions(
+        actions: wizardActions(controller: controller),
+        child: Wizard(
+          controller: controller,
+          initialRoute: Routes.initial,
+          routes: <String, WizardRoute>{
+            Routes.welcome: WizardRoute(
+              builder: WelcomePage.create,
+            ),
+            Routes.chooser: WizardRoute(
+              builder: ChooserPage.create,
+              onNext: (settings) {
+                switch (settings.arguments as Choice?) {
+                  case Choice.preview:
+                    return Routes.preview;
+                  case Choice.install:
+                    if (!context.read<NetworkModel>().isConnected) {
+                      return Routes.connect;
+                    }
+                    return Routes.install;
+                  default:
+                    throw ArgumentError(settings.arguments);
+                }
+              },
+            ),
+            Routes.preview: WizardRoute(
+              builder: PreviewPage.create,
+            ),
+            Routes.connect: WizardRoute(
+              builder: ConnectPage.create,
+              onBack: (_) => Routes.chooser,
+            ),
+            Routes.install: WizardRoute(
+              builder: InstallPage.create,
+              onBack: (_) => Routes.chooser,
+            ),
+          },
+        ),
       ),
     );
   }

--- a/example/lib/pages/chooser_page.dart
+++ b/example/lib/pages/chooser_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:wizard_router_example/actions.dart';
+import 'package:wizard_router_example/main.dart';
 
 import '../models.dart';
 import '../widgets.dart';
@@ -65,12 +67,17 @@ class ChooserPage extends StatelessWidget {
       actions: [
         WizardAction(
           label: 'Back',
-          onActivated: Wizard.of(context).back,
+          onActivated: () => WizardApp.useActions
+              ? WizardBackIntent.invoke(context: context)
+              : Wizard.of(context).back(),
         ),
         WizardAction(
           label: 'Next',
           onActivated: model.value != Choice.none
-              ? () => Wizard.of(context).next(arguments: model.value)
+              ? () => WizardApp.useActions
+                  ? WizardNextIntent.invoke(
+                      context: context, arguments: model.value)
+                  : Wizard.of(context).next(arguments: model.value)
               : null,
         ),
       ],

--- a/example/lib/pages/welcome_page.dart
+++ b/example/lib/pages/welcome_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:wizard_router_example/actions.dart';
+import 'package:wizard_router_example/main.dart';
 
 import '../widgets.dart';
 
@@ -38,7 +40,9 @@ interaction and an imaginary network service.
       actions: [
         WizardAction(
           label: 'Next',
-          onActivated: Wizard.of(context).next,
+          onActivated: () => WizardApp.useActions
+              ? WizardNextIntent.invoke(context: context)
+              : Wizard.of(context).next(),
         ),
       ],
     );

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,0 +1,60 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:flutter/material.dart';
+
+/// The set of actions that a controller can accept
+enum WizardControllerAction {
+  home,
+  back,
+  next,
+  replace,
+  done,
+  unknown,
+}
+
+/// Allows widgets such as the AppBar to invoke functionality on the Wizard
+/// This is useful for widgets that are defined above the Wizard, such as a mobile
+/// app's AppBar.
+class WizardController extends ChangeNotifier {
+  WizardControllerAction action = WizardControllerAction.unknown;
+  Object? arguments;
+
+  /// Since each Page is wrapped with WizardScope we must ensure there is only
+  /// ever one listener. This overrides ensures there is only one listener.
+  /// Since the WizardScope takes in the Controller, the listener can be
+  /// added N times, depending on how many routes are generated.
+  @override
+  void addListener(VoidCallback listener) {
+    if (!hasListeners) {
+      super.addListener(listener);
+    }
+  }
+
+  void home() {
+    action = WizardControllerAction.home;
+    notifyListeners();
+  }
+
+  void done({Object? result}) {
+    action = WizardControllerAction.done;
+    this.arguments = result;
+    notifyListeners();
+  }
+
+  void replace({Object? arguments}) {
+    action = WizardControllerAction.replace;
+    this.arguments = arguments;
+    notifyListeners();
+  }
+
+  void next({Object? arguments}) {
+    action = WizardControllerAction.next;
+    this.arguments = arguments;
+    notifyListeners();
+  }
+
+  void back({Object? arguments}) {
+    action = WizardControllerAction.back;
+    this.arguments = arguments;
+    notifyListeners();
+  }
+}

--- a/lib/src/wizard.dart
+++ b/lib/src/wizard.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flow_builder/flow_builder.dart';
 import 'package:flutter/material.dart';
+import 'package:wizard_router/src/controller.dart';
 
 import 'observer.dart';
 import 'result.dart';
@@ -115,6 +116,7 @@ class Wizard extends StatefulWidget {
     required this.routes,
     this.observers = const [],
     this.userData,
+    this.controller,
   });
 
   /// The name of the first route to show.
@@ -181,6 +183,8 @@ class Wizard extends StatefulWidget {
 
   final List<WizardObserver> observers;
 
+  final WizardController? controller;
+
   @override
   State<Wizard> createState() => _WizardState();
 }
@@ -221,6 +225,7 @@ class _WizardState extends State<Wizard> {
         route: widget.routes[settings.name]!,
         routes: widget.routes.keys.toList(),
         userData: widget.userData,
+        controller: widget.controller,
       ),
     );
   }

--- a/lib/wizard_router.dart
+++ b/lib/wizard_router.dart
@@ -11,3 +11,4 @@ export 'src/observer.dart';
 export 'src/route.dart';
 export 'src/scope.dart';
 export 'src/wizard.dart';
+export 'src/controller.dart';


### PR DESCRIPTION
This new optional controller allows for developers to control the wizard without the need for context or if the widget trying to control the wizard is above the wizard's context.

This was implemented to allow Mobile AppBar's BackButton to call Wizard's Back.

There is a bit of a workaround with this implementation because of how WizardScope is tied to each generated Page. The controller must check for "hasListeners" to ensure only one listener is added.

Otherwise without this check, each WizardScope will attach its own controller listener. This has the drastic side effect of multiple listeners calling next or back or whatever action is triggered.

I can understand why the Wizard Router is designed this way but it would probably make more sense to have one WizardScope rather than several, and allow wizard scope to accept functions rather than try to handle everything internally within the Wizard class.

However this is a larger change, outside the scope of this optional controller pattern.

There is a new file called actions.dart which demonstrates the use and need of the controller.