### PR TITLE
WizardScopeState: expose WizardController

### DIFF
--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -88,6 +88,8 @@ class WizardScopeState extends State<WizardScope> {
     return previousIndex < routes.length - 1;
   }
 
+  WizardController get controller => widget._controller;
+
   Object? get routeData => widget._route.userData;
   Object? get wizardData => widget._userData;
 


### PR DESCRIPTION
Exposes the `WizardController` on the scope, so it can be accessed by `Wizard.of(context).controller`