### PR TITLE
add onLoad callback

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -70,6 +70,8 @@ class WizardController extends ChangeNotifier {
     final next =
         await _getNextRoute<T>(arguments, routes[currentRoute]!.onNext);
 
+    await routes[next.name]!.onLoad?.call(next);
+
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);
       return copy..add(next);
@@ -114,6 +116,8 @@ class WizardController extends ChangeNotifier {
     final next =
         await _getNextRoute<T>(arguments, routes[currentRoute]!.onReplace);
 
+    await routes[next.name]!.onLoad?.call(next);
+
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);
       copy[copy.length - 1] = next;
@@ -128,6 +132,8 @@ class WizardController extends ChangeNotifier {
     assert(routes.keys.contains(route),
         '`Wizard.jump()` called with an unknown route $route.');
     final settings = WizardRouteSettings<T>(name: route, arguments: arguments);
+
+    await routes[route]!.onLoad?.call(settings);
 
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);

--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -6,12 +6,15 @@ import 'package:flutter/widgets.dart';
 typedef WizardRouteCallback = FutureOr<String?> Function(
     RouteSettings settings);
 
+typedef WizardRouteLoader = FutureOr<void> Function(RouteSettings settings);
+
 class WizardRoute {
   const WizardRoute({
     required this.builder,
     this.onNext,
     this.onReplace,
     this.onBack,
+    this.onLoad,
     this.userData,
   });
 
@@ -34,6 +37,9 @@ class WizardRoute {
   /// If `onBack` is not specified or it returns `null`, the order is determined
   /// from [routes].
   final WizardRouteCallback? onBack;
+
+  /// The callback invoked when the page is loaded.
+  final WizardRouteLoader? onLoad;
 
   /// Additional custom data associated with this page.
   final Object? userData;

--- a/test/wizard_router_test.dart
+++ b/test/wizard_router_test.dart
@@ -895,4 +895,46 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text(Routes.first), findsOneWidget);
   });
+
+  testWidgets('onLoad', (tester) async {
+    var calls = 0;
+    final controller = WizardController(
+      routes: {
+        Routes.first: WizardRoute(builder: (_) => const Text(Routes.first)),
+        Routes.second: WizardRoute(
+          builder: (_) => const Text(Routes.second),
+          onLoad: (_) => calls++,
+        ),
+        Routes.third: WizardRoute(builder: (_) => const Text(Routes.third)),
+      },
+    );
+    await pumpWizardApp(tester, controller: controller);
+    await tester.pumpAndSettle();
+    expect(calls, 0);
+
+    controller.next();
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+
+    controller.next();
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+
+    controller.back();
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+
+    controller.home();
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+
+    controller.jump(Routes.second);
+    await tester.pumpAndSettle();
+    expect(calls, 2);
+
+    controller.home();
+    controller.replace();
+    await tester.pumpAndSettle();
+    expect(calls, 3);
+  });
 }


### PR DESCRIPTION
Adds an `onLoad` callback to `Wizard`, that is invoked when a route is pushed via `next()`, `jump()` or `replace()`.