### PR TITLE
onLoad: add return value to allow guarding routes

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -15,10 +15,17 @@ class WizardController extends ChangeNotifier {
 
   int _loading = 0;
   bool get isLoading => _loading > 0;
-  Future<void> _loadRoute(WizardRouteSettings settings) async {
+  Future<WizardRouteSettings<T>> _loadRoute<T>(
+    String name,
+    Future<WizardRouteSettings<T>> Function(String name) getRoute,
+  ) async {
     if (++_loading == 1) notifyListeners();
     try {
-      await routes[settings.name]!.onLoad?.call(settings);
+      var next = await getRoute(name);
+      while (await routes[next.name]!.onLoad?.call(next) == false) {
+        next = await getRoute(next.name!);
+      }
+      return next;
     } finally {
       if (--_loading == 0) notifyListeners();
     }
@@ -78,10 +85,9 @@ class WizardController extends ChangeNotifier {
   /// Requests the wizard to show the next page. Optionally, `arguments` can be
   /// passed to the next page.
   Future<T?> next<T extends Object?>({Object? arguments}) async {
-    final next =
-        await _getNextRoute<T>(arguments, routes[currentRoute]!.onNext);
-
-    await _loadRoute(next);
+    final next = await _loadRoute<T>(currentRoute, (name) {
+      return _getNextRoute<T>(name, arguments, routes[name]!.onNext);
+    });
 
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);
@@ -91,14 +97,15 @@ class WizardController extends ChangeNotifier {
     return next.completer.future;
   }
 
-  Future<WizardRouteSettings<T?>> _getNextRoute<T extends Object?>(
+  Future<WizardRouteSettings<T>> _getNextRoute<T extends Object?>(
+    String from,
     Object? arguments,
     WizardRouteCallback? advance,
   ) async {
     assert(state.isNotEmpty, state.length.toString());
 
     final previous = WizardRouteSettings(
-      name: state.last.name,
+      name: from,
       arguments: arguments,
     );
 
@@ -118,16 +125,15 @@ class WizardController extends ChangeNotifier {
     assert(routes.keys.contains(name),
         '`Wizard.routes` is missing route \'$name\'.');
 
-    return WizardRouteSettings<T?>(name: name, arguments: arguments);
+    return WizardRouteSettings<T>(name: name, arguments: arguments);
   }
 
   /// Requests the wizard to replace the current page with the next one.
   /// Optionally, `arguments` can be passed to the next page.
   Future<T?> replace<T extends Object?>({Object? arguments}) async {
-    final next =
-        await _getNextRoute<T>(arguments, routes[currentRoute]!.onReplace);
-
-    await _loadRoute(next);
+    final next = await _loadRoute<T>(currentRoute, (name) {
+      return _getNextRoute<T>(name, arguments, routes[name]!.onReplace);
+    });
 
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);
@@ -142,9 +148,9 @@ class WizardController extends ChangeNotifier {
   Future<T?> jump<T extends Object?>(String route, {Object? arguments}) async {
     assert(routes.keys.contains(route),
         '`Wizard.jump()` called with an unknown route $route.');
-    final settings = WizardRouteSettings<T>(name: route, arguments: arguments);
-
-    await _loadRoute(settings);
+    final settings = await _loadRoute(route, (name) async {
+      return WizardRouteSettings<T>(name: name, arguments: arguments);
+    });
 
     _updateState((state) {
       final copy = List<WizardRouteSettings>.of(state);

--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -6,7 +6,8 @@ import 'package:flutter/widgets.dart';
 typedef WizardRouteCallback = FutureOr<String?> Function(
     RouteSettings settings);
 
-typedef WizardRouteLoader = FutureOr<void> Function(RouteSettings settings);
+/// The signature of [WizardRoute.onLoad] callback.
+typedef WizardRouteLoader = FutureOr<bool> Function(RouteSettings settings);
 
 class WizardRoute {
   const WizardRoute({
@@ -39,6 +40,8 @@ class WizardRoute {
   final WizardRouteCallback? onBack;
 
   /// The callback invoked when the page is loaded.
+  ///
+  /// If `onLoad` is specified and returns `false`, the page is skipped.
   final WizardRouteLoader? onLoad;
 
   /// Additional custom data associated with this page.

--- a/test/wizard_router_test.dart
+++ b/test/wizard_router_test.dart
@@ -905,43 +905,54 @@ void main() {
         Routes.first: WizardRoute(builder: (_) => const Text(Routes.first)),
         Routes.second: WizardRoute(
           builder: (_) => const Text(Routes.second),
-          onLoad: (_) => calls++,
+          onLoad: (_) => ++calls > 0,
         ),
-        Routes.third: WizardRoute(builder: (_) => const Text(Routes.third)),
+        Routes.third: WizardRoute(
+          builder: (_) => const Text(Routes.third),
+          onLoad: (_) => false,
+        ),
+        Routes.fourth: WizardRoute(builder: (_) => const Text(Routes.fourth)),
       },
     );
     await pumpWizardApp(tester, controller: controller);
     await tester.pumpAndSettle();
     expect(calls, 0);
+    expect(find.text(Routes.first), findsOneWidget);
 
     controller.next();
     await tester.pumpAndSettle();
     expect(calls, 1);
+    expect(find.text(Routes.second), findsOneWidget);
 
     controller.next();
     await tester.pumpAndSettle();
     expect(calls, 1);
+    expect(find.text(Routes.fourth), findsOneWidget);
 
     controller.back();
     await tester.pumpAndSettle();
     expect(calls, 1);
+    expect(find.text(Routes.second), findsOneWidget);
 
     controller.home();
     await tester.pumpAndSettle();
     expect(calls, 1);
+    expect(find.text(Routes.first), findsOneWidget);
 
     controller.jump(Routes.second);
     await tester.pumpAndSettle();
     expect(calls, 2);
+    expect(find.text(Routes.second), findsOneWidget);
 
     controller.home();
     controller.replace();
     await tester.pumpAndSettle();
     expect(calls, 3);
+    expect(find.text(Routes.second), findsOneWidget);
   });
 
   testWidgets('loading state', (tester) async {
-    final completer = Completer<void>();
+    final completer = Completer<bool>();
     final controller = WizardController(routes: {
       Routes.first: WizardRoute(builder: (_) => const Text(Routes.first)),
       Routes.second: WizardRoute(
@@ -973,7 +984,7 @@ void main() {
     expect(controller.isLoading, isTrue);
     expect(wasNotified, equals(1));
 
-    completer.complete();
+    completer.complete(true);
     await tester.pumpAndSettle();
     expect(firstPage, findsNothing);
     expect(secondPage, findsOneWidget);


### PR DESCRIPTION
### Before

The "locale" route decides what comes next. Therefore, it needs to know what other routes there are. When the available routes are dynamically configured, there may not be any "welcome" or "keyboard" routes so the decision on "onNext" becomes complicated.

```dart
Wizard(
  routes: {
    Routes.locale: WizardRoute(
      builder: (_) => const LocalePage(),
      onNext: (_) => widget.welcome ? Routes.welcome : Routes.keyboard,
    ),
    Routes.welcome: WizardRoute(
      builder: (_) => const WelcomePage(),
    ),
    Routes.keyboard: WizardRoute(
      builder: (_) => const KeyboardPage(),
    ),
  },
)
```

### After

Routes are fully standalone as they can decide by themselves if they are used or skipped.

```dart
Wizard(
  routes: {
    Routes.locale: WizardRoute(
      builder: (_) => const LocalePage(),
    ),
    Routes.welcome: WizardRoute(
      builder: (_) => const WelcomePage(),
      onLoad: (_) => widget.welcome,
    ),
    Routes.keyboard: WizardRoute(
      builder: (_) => const KeyboardPage(),
    ),
  },
)
```