### PR TITLE
ci: switch from deprecated `flutter format` to `dart format`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - run: flutter pub get
-      - run: flutter format --set-exit-if-changed .
+      - run: dart format --set-exit-if-changed .
 
   linux:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
> The "format" command is deprecated. Please use the "dart format" sub-command instead, which has the same command-line usage as "flutter format".

https://github.com/ubuntu-flutter-community/wizard_router/actions/runs/4944902190/jobs/8840913408?pr=51