### PR TITLE
fix(controller): prevent notifying listeners after being disposed

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -12,6 +12,7 @@ class WizardController extends ChangeNotifier {
   final String? initialRoute;
   final Map<String, WizardRoute> routes;
   late final FlowController<List<WizardRouteSettings>> _flowController;
+  bool _wasDisposed = false;
 
   int _loading = 0;
   bool get isLoading => _loading > 0;
@@ -27,7 +28,7 @@ class WizardController extends ChangeNotifier {
       }
       return next;
     } finally {
-      if (--_loading == 0) notifyListeners();
+      if (--_loading == 0 && !_wasDisposed) notifyListeners();
     }
   }
 
@@ -37,11 +38,12 @@ class WizardController extends ChangeNotifier {
   void _updateState(
     List<WizardRouteSettings> Function(List<WizardRouteSettings>) callback,
   ) {
-    _flowController.update(callback);
+    if (!_wasDisposed) _flowController.update(callback);
   }
 
   @override
   void dispose() {
+    _wasDisposed = true;
     _flowController.removeListener(notifyListeners);
     _flowController.dispose();
     super.dispose();


### PR DESCRIPTION
Fixes:
```
flutter: ERROR ubuntu_desktop_installer: Unhandled exception
_AssertionError: 'package:wizard_router/src/controller.dart': Failed assertion: line 119 pos 14: 'index < routeNames.length - 1': `Wizard.next()` called from the last route /security-key.
controller.dart:119
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:51:61)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:40:5)
#2      WizardController._getNextRoute.nextRoute
controller.dart:119
#3      WizardController._getNextRoute
controller.dart:124
<asynchronous suspension>
#4      WizardController._loadRoute
controller.dart:26
<asynchronous suspension>
#5      WizardController.next
controller.dart:88
<asynchronous suspension>
#6      WizardButton.next.<anonymous closure>.<anonymous closure>
wizard_button.dart:87
<asynchronous suspension>
```

Close: #53